### PR TITLE
Add base exception class that all exceptions will extend

### DIFF
--- a/Auth/Exceptions/AuthenticationException.php
+++ b/Auth/Exceptions/AuthenticationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dvsa\Contracts\Auth\Exceptions;
+
+/**
+ * The base exception for all exceptions in the Auth contracts.
+ */
+interface AuthenticationException extends \Throwable
+{
+}


### PR DESCRIPTION
Ticket: BL-12236

This MR:
- Adds a simple (and bare) base exception - All authentication exceptions will extend this. This allows consumers to `try/catch` our exceptions across all of the auth adapters.
- Also allow tickets in sprint to be worked on in parallel, as register and login tickets will need to create exceptions.