### PR TITLE
Investigate Snyk issue

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/php@master
-        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --sarif-file-output=snyk.sarif
 
       - name: Upload result to GitHub Code Scanning
+        if: ${{ success() || failure() }}
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: snyk.sarif

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "ext-json": "*",
         "league/oauth2-client": "^2.6"
     },
+    "conflict": {
+        "guzzlehttp/guzzle": "<6.2.1"
+    },
     "replace": {
         "paragonie/random_compat": "9.99.99"
     },


### PR DESCRIPTION
**Reason:**
Snyk failed on a `guzzle` security vulnerability but didn't fail the actions. The vulnerability only affects PHP 7.0.8, so not a massive issue, but it did highlight this issue: Snyk action was set to `continue-on-failure` to allow the code report to be uploaded to GitHub.

**This MR:**
Will remove the `continue-on-failure` and instead opt for a conditional that will always run the code scanning serif upload while still failing the required action.