### PR TITLE
Add `getResourceOwner` method

### DIFF
--- a/Auth/OAuthClientInterface.php
+++ b/Auth/OAuthClientInterface.php
@@ -17,6 +17,8 @@ interface OAuthClientInterface
     public function enableUser(string $identifier): bool;
     public function disableUser(string $identifier): bool;
 
+    public function getResourceOwner(AccessTokenInterface $token): ResourceOwnerInterface;
+
     public function decodeToken(string $token): array;
 
     public function refreshTokens(string $refreshToken, string $identifier): AccessTokenInterface;


### PR DESCRIPTION
This PR:
- Add an additional method that will allow us to be more consistent with the OAuth2 spec. Retrieving the resource owner I see as a vital method we should normalise between `league/oauth-client` and this package.