### PR TITLE
Add trait to create custom resource owner class

### DIFF
--- a/Auth/CreatesResourceOwners.php
+++ b/Auth/CreatesResourceOwners.php
@@ -3,21 +3,19 @@ declare(strict_types=1);
 
 namespace Dvsa\Contracts\Auth;
 
-use League\OAuth2\Client\Provider\GenericResourceOwner;
-
 trait CreatesResourceOwners
 {
     /**
-     * @var string
-     * @psalm-var class-string<ResourceOwnerInterface>
+     * @var null|string
+     * @psalm-var null|class-string<ResourceOwnerInterface>
      */
-    protected $resourceOwnerClass = GenericResourceOwner::class;
+    protected $resourceOwnerClass = null;
 
     /**
-     * @return string
-     * @psalm-return class-string<ResourceOwnerInterface>
+     * @return null|string
+     * @psalm-return null|class-string<ResourceOwnerInterface>
      */
-    public function getResourceOwnerClass(): string
+    public function getResourceOwnerClass(): ?string
     {
         return $this->resourceOwnerClass;
     }
@@ -37,9 +35,19 @@ trait CreatesResourceOwners
 
     /**
      * Creates a resource owner object using the provided class name.
+     * If no class string was provided, an anonymous class will be returned using `id` as the `getId()` key.
      */
-    protected function createResourceOwner(array $claims, string $resourceOwnerId = 'id'): ResourceOwnerInterface
+    protected function createResourceOwner(array $claims): ResourceOwnerInterface
     {
-        return new $this->resourceOwnerClass($claims, $resourceOwnerId);
+        if (!isset($this->resourceOwnerClass)) {
+            return new class($claims) extends AbstractResourceOwner implements ResourceOwnerInterface {
+                public function getId(): string
+                {
+                    return $this->get('id');
+                }
+            };
+        }
+
+        return new $this->resourceOwnerClass($claims);
     }
 }

--- a/Auth/CreatesResourceOwners.php
+++ b/Auth/CreatesResourceOwners.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Dvsa\Contracts\Auth;
+
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+
+trait CreatesResourceOwners
+{
+    /**
+     * @var string
+     * @psalm-var class-string<ResourceOwnerInterface>
+     */
+    protected $resourceOwnerClass = GenericResourceOwner::class;
+
+    /**
+     * @return string
+     * @psalm-return class-string<ResourceOwnerInterface>
+     */
+    public function getResourceOwnerClass(): string
+    {
+        return $this->resourceOwnerClass;
+    }
+
+    /**
+     * @param  string  $class
+     * @psalm-param class-string<ResourceOwnerInterface> $class
+     *
+     * @return self
+     */
+    public function setResourceOwnerClass(string $class): self
+    {
+        $this->resourceOwnerClass = $class;
+
+        return $this;
+    }
+
+    /**
+     * Creates a resource owner object using the provided class name.
+     */
+    protected function createResourceOwner(array $claims, string $resourceOwnerId = 'id'): ResourceOwnerInterface
+    {
+        return new $this->resourceOwnerClass($claims, $resourceOwnerId);
+    }
+}

--- a/Auth/OAuthClientInterface.php
+++ b/Auth/OAuthClientInterface.php
@@ -64,7 +64,7 @@ interface OAuthClientInterface
     public function refreshTokens(string $refreshToken, string $identifier): AccessTokenInterface;
 
     /**
-     * @throws ClientException when there is an issue with authenticating a user.
+     * @throws ClientException when there is an issue with finding a user.
      */
     public function getUserByIdentifier(string $identifier): ResourceOwnerInterface;
 }


### PR DESCRIPTION
**This MR:**
Will make a trait available that will allow adapters to reuse code that will facilitate the ability to return custom return objects. Completely optional to use in an adapter, and _doesn't break backwards compatibility_.

The trait will add 3 methods to the parent: `createResourceOwner`, `getResourceOwnerClass` & `setResourceOwnerClass`.

If a default resource owner class isn't specified in the adapter's constructor, or as part of the application code, an anonymous class will be returned that implements the `ResourceOwnerInterface`.

**Use case:**
In MOT, we want to model our return objects with our current user schema. To strongly type these additional methods, it would be useful to be able to return these directly from the adapters rather than the need of another object.

**Example usage:**
###### Within Adapter:
```php
use Dvsa\Contracts\Auth\CreatesResourceOwners;

class Adapter
{
    use CreatesResourceOwners;

    public function __construct(...$args)
    {
        // ...
        $this->resourceOwnerClass = AdapterDefaultResourceOwner::class
    }

    public function getResourceOwner($token)
    {
        // ... 
        return $this->createResourceOwner($tokenClaims);
    }
}
```

###### Within Applications:
```php
$adapter = new Adapter([]);

$adapter->setResourceOwnerClass(MyCustomResourceOwner::class);
```