### PR TITLE
Update method visibility of `createResourceOwner`

### DIFF
--- a/Auth/CreatesResourceOwners.php
+++ b/Auth/CreatesResourceOwners.php
@@ -37,7 +37,7 @@ trait CreatesResourceOwners
      * Creates a resource owner object using the provided class name.
      * If no class string was provided, an anonymous class will be returned using `id` as the `getId()` key.
      */
-    protected function createResourceOwner(array $claims): ResourceOwnerInterface
+    public function createResourceOwner(array $claims): ResourceOwnerInterface
     {
         if (!isset($this->resourceOwnerClass)) {
             return new class($claims) extends AbstractResourceOwner implements ResourceOwnerInterface {


### PR DESCRIPTION
This MR:
- Changes the visibility of `createResourceOwner` to public.

#### Example usage
###### In application
```php
// ...
// Receive token from external service.
$claims = $this->client->decodeToken($accessToken);

$resourceOwner = $this->client->createResourceOwner($claims);

$userRepository->getUserByUsername($resourceOwner->getUsername());
```